### PR TITLE
feat(magi): switch merge mode to pr for machine-wide config

### DIFF
--- a/home/.config/magi/config.toml
+++ b/home/.config/magi/config.toml
@@ -120,6 +120,26 @@ mode = "notify"
 # it in its own magi.toml.
 [merge]
 base = "main"
+# `mode` は既定の `"none"` から離れ、`"pr"` にする。`"none"` はブランチを残して
+# 手でマージするコマンドを表示するだけで、その「手で」を誰もやらないと直った
+# はずのものが直っていないまま止まる。run `20260907-075524-520f`
+# （クォータ切れの run がタスクの attempt を食い潰す問題の修正）がまさにそれで、
+# レビューもゲートも通って `ready` になったのに放置され、人手で PR #98 に
+# されるまでマージされなかった。
+#
+# `"local"` にしないのは、このマシンの checkout が全て jj-colocated だから
+# （上の `base` のコメントと同じ事情）。`"local"` は主ワークツリーで
+# `git merge --no-ff` する経路で、jj が detach させている working-copy の HEAD に
+# 触らせたくない。`"pr"` ならブランチを push して `gh pr create` するだけで
+# working copy に触らず、CI も回り、最後のマージ承認は magi web の Questions
+# 画面に出るのでスマホから完結できる。
+#
+# 代償もある: `land()` は承認が来るまで `attempt()` の中でブロックし、その間
+# キューは1件も進まない。夜中に1件が承認待ちになれば backlog 全体が朝まで
+# 止まる。これはキュー済みタスク `20260907-...-4063`
+# 「働いていない run にキューのスロットを占有させない」で直る予定の既知の
+# 欠陥で、それまでは承認をためないという運用で凌ぐ。
+mode = "pr"
 
 # The one thing every repository in this fleet has to tell a magi node, for the
 # same reason. Repository-specific conventions stay in each repo's own


### PR DESCRIPTION
`magi run 20260907-154944-c661` の勝者ブランチ。task `マシン設定の [merge] を mode = "pr" にして、run が PR を立ててマージまで到達するようにする`。

## なぜ

`home/.config/magi/config.toml` の `[merge]` に `mode` が無く、magi 側の既定 `MergeMode::None` が効いていた。`None` は「ブランチを残してマージコマンドを表示するだけ」なので、run はゲートを通ったあと `ready` で止まる。

その結果、**レビューもゲートも通った成果が15 run ぶん `ready` のまま滞留した**。中には `20260907-075524-520f`（クォータ切れが attempt を食い潰す問題の修正）も含まれていて、これがマージされていれば 2026-09-07 02:51 に backlog 34件中26件が `held` に落ちた事故は起きなかった。

## 変更

`[merge]` に `mode = "pr"` を追加。run はブランチを push して `gh pr create` で PR を開き、`land()` が CI とレビューコメントを処理したうえでマージ承認をオペレーターに尋ね、承認されれば `gh pr merge` まで実行する。承認は magi web の Questions 画面に出るのでスマホから完結する。

`"local"` を選ばなかったのは、このマシンの checkout が全て jj-colocated で git の HEAD が detach したままであり、主ワークツリーで `git merge` させたくないため。

`home/.config/magi/config.toml` の1ファイル、+20 / -0。設定値の追加は `mode` の1行のみで、残りは理由を述べるコメント。

## 既知の代償

承認待ちの間デーモンは `attempt()` の中でブロックし、その間キューは1件も進まない。この欠陥はキュー済みタスク「働いていない run にキューのスロットを占有させない」（勝者ブランチ `magi/a81d/A`、これも `ready` で滞留中）で直る。それまでは承認をためないことで運用する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Pull request mode is now explicitly enabled for merge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->