### PR TITLE
docs(magi): fix [roles] comments to match planner/chatter/talk split

### DIFF
--- a/home/.config/magi/config.toml
+++ b/home/.config/magi/config.toml
@@ -76,7 +76,9 @@ reviewers = ["cx", "sonnet"]
 # fixes. Left as it is on purpose: the reason above is cost, not correctness,
 # and the seat that just wrote the patch is the one that knows why.
 fixer = "sonnet"
-# Who runs the `magi plan` interview and the browser conversation.
+# Who runs the `magi plan` CLI interview. Also the fallback for `chatter`
+# below when that is unset, so Planning and Talk land here too if nobody
+# picked a chatter.
 #
 # Pinned because the interview is the one node a human sits through: the model
 # that asks the sharpest questions is not necessarily the one that writes the
@@ -84,10 +86,11 @@ fixer = "sonnet"
 #
 # `--agent <id>` and the web UI's own agent field still override this per call.
 planner = "opus"
-# The resident chat's own default, separate from planner on purpose: it opens
-# far more often than `magi plan`, and opus is also a judge seat above - the
-# two together caused a chat turn to time out (`agent opus did not answer
-# within 300s`) while a competition's judge wave was running concurrently.
+# Default for the Planning interview (web UI) and the resident Talk
+# conversation, separate from planner on purpose: these open far more often
+# than `magi plan`, and opus is also a judge seat above - the two together
+# caused a chat turn to time out (`agent opus did not answer within 300s`)
+# while a competition's judge wave was running concurrently.
 chatter = "sonnet"
 
 # The shape of a run is a preference about time and money, not about any one


### PR DESCRIPTION
`magi run 20260907-070920-50a5` の勝者ブランチ。

`home/.config/magi/config.toml` の `[roles]` 節のコメントが magi 本体の実態とずれていたのを直す。**設定値は変えない。コメントだけの変更。**

`home/.config/magi/config.toml` +8 / -5。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the roles configuration comments for `planner` and `chatter`.
  - Documented how planning interviews and ongoing conversations are assigned when roles are configured or left unset.
  - No configuration values or runtime behavior were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->