### PR TITLE
feat(magi): pin plan advisors to exclude agy from design-advise seats

### DIFF
--- a/home/.config/magi/config.toml
+++ b/home/.config/magi/config.toml
@@ -64,6 +64,14 @@ implementers = ["sonnet", "cx", "oc", "agy"]
 # Rotated so no judge sits on its own candidate. Only matters when a task asks
 # for more than one candidate.
 judges = ["opus", "agy", "cx"]
+# `Config::advisors()` falls back to `judges` when this is unset, and that
+# roster still carries `agy`. A judge wave runs inside an unattended
+# implementation run, so a dropped stream just costs the run some wall-clock;
+# `magi plan`'s advise stage sits right after the interview, with a human
+# waiting on the other end, so the same defect there means someone stares at
+# a screen for up to `timeout_judge` (1200s, unset here). Stated explicitly as
+# `judges` minus `agy`.
+advisors = ["cx", "sonnet", "opus"]
 # `cx` is the only seat whose read-only-ness the CLI enforces (`--sandbox
 # read-only`), which is exactly what a reviewer is: it cannot touch the tree it
 # is reviewing even if it decides to.

--- a/home/.config/magi/config.toml
+++ b/home/.config/magi/config.toml
@@ -69,8 +69,11 @@ judges = ["opus", "agy", "cx"]
 # implementation run, so a dropped stream just costs the run some wall-clock;
 # `magi plan`'s advise stage sits right after the interview, with a human
 # waiting on the other end, so the same defect there means someone stares at
-# a screen for up to `timeout_judge` (1200s, unset here). Stated explicitly as
-# `judges` minus `agy`.
+# a screen for up to `timeout_judge` (1200s, unset here). Dropping `agy` from
+# `judges` leaves only `opus` and `cx`, one short of the three candidates
+# `graph.advisors` asks for by default, so `sonnet` fills the seat: it is
+# already trusted with `chatter` and the top `implementers` slot, with none
+# of `agy`'s reporting defect above.
 advisors = ["cx", "sonnet", "opus"]
 # `cx` is the only seat whose read-only-ness the CLI enforces (`--sandbox
 # read-only`), which is exactly what a reviewer is: it cannot touch the tree it


### PR DESCRIPTION
`magi run 20260907-...-2bd0` の勝者ブランチ。task「magi のマシン設定に `[roles] advisors` を明示して agy を設計合議から外す」。

`[roles]` に `advisors` を明示し、`agy` を設計合議の席から外す。`advisors` を書かない場合の既定は `judges` からの導出で、そこに `agy` が入ってしまうため。あわせて、その導出関係を説明するコメントを直す。

`home/.config/magi/config.toml` +11 / -0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Updated the default advisor roster to include CX, Sonnet, and Opus.
  - Added fallback behavior using the judge roster when no advisor roster is configured.
  - Removed Agy from the default judge selection due to unreliable stream reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->