### PR TITLE
Merge magi run 20260909-053142-a638 (candidate A)

### DIFF
--- a/home/.config/magi/config.toml
+++ b/home/.config/magi/config.toml
@@ -181,3 +181,17 @@ mode = "pr"
 all = """
 This repository uses jj (Jujutsu) with a colocated git repo. `git commit` works in a candidate worktree and is what magi expects, but never run `jj` commands and never touch the main working copy.
 """
+
+# Which checkouts exist on disk is a fact about this machine, same reasoning
+# as the agent roster above. `roots` is an array key too, so it can only be
+# declared in one config layer, and this machine layer is the only place that
+# can hold it - a repository's own magi.toml can't add to it.
+[repos]
+# Every checkout here follows the ghq layout, so one root covers all of them.
+# The path is resolved through `home()` rather than hardcoded, so this file
+# still works unchanged if it ever runs on another machine.
+#
+# Single-quoted on purpose: `home()` returns a backslash-separated path on
+# Windows, and a TOML basic (double-quoted) string would try to interpret
+# those backslashes as escapes and fail to parse.
+roots = ['{{ home() }}/src']


### PR DESCRIPTION
Merge magi run 20260909-053142-a638 (candidate A)

このリポジトリの `config.toml` は magi の machine 設定レイヤ（`<config_dir>/magi/config.toml`）そのものである。ここに `[repos]` テーブルを追加し、ホームディレクトリ配下の ghq ルートを走査対象にする。

## 背景（コミットメッセージやコメントの根拠として使ってよい）

- magi の web UI / `magi plan` にあるリポジトリ選択は選択式だが、選択肢は `[repos] roots` を走査した結果で埋まる。既定は空配列なので、設定しない限り選択肢が一件も出ない。
- 走査は ghq レイアウト固定で `<root>/<host>/<owner>/<repo>` に `.git` があるディレクトリだけを拾う（magi 本体の `src/repos.rs`）。このマシンの checkout は `<home>/src/github.com/<owner>/<repo>` に揃っているので、root は `<home>/src` 一つで全部拾える。
- `roots` は配列キーなので magi の config レイヤのうち一箇所でしか宣言できず、宣言できるのは machine レイヤ＝この `config.toml` だけ（リポジトリ側の `magi.toml` には書けない）。

## 必須要件：パスをハードコードせず teravars で解決する

magi の config は teravars 経由で Tera レンダリングされてから TOML としてパースされる。teravars の std-helpers には `home()` 関数があり（`dirs::home_dir` 相当。Unix では `$HOME`、Windows では `%USERPROFILE%`）、これを使えば同じ一行がどの OS でも通る。`~` はシェルの機能であって magi は展開しないので使ってはいけない。

したがって書くべき値は次の形（クォート含めてこのとおり）:

```toml
roots = ['{{ home() }}/src']
```

**シングルクォート（TOML のリテラル文字列）であることが必須。** ダブルクォートで書くと Windows で壊れる。実測結果:

- `roots = ["{{ home() }}/src"]` は teravars が `roots = ["C:\Users\yukimemi/src"]` にレンダリングし、`\U` が TOML の不正なエスケープなのでパースエラーになり magi 全体が起動不能になる
- シングルクォート版はリテラル文字列がエスケープを解釈しないので通り、`magi repos` が実際にチェックアウト一覧を返した

## やること

1. `config.toml` の末尾付近、他のテーブル（`[update]` / `[merge]` / `[prompts]` など）と同じ体裁で `[repos]` テーブルを追加する。
2. 上記のシングルクォート形式で `roots` を設定する。`scan_ttl` は既定（86400 秒）のままでよいので書かない。
3. このファイルの既存コメントは「なぜその値なのか」を英語の散文で長めに書くスタイルなので、それに合わせて `[repos]` にも英語のコメントを付ける。書くべき中身は次の三点:
   - どのチェックアウトがディスク上に存在するかはマシンの事実なので、agent roster と同じくこのレイヤに属する。そもそも `roots` は配列なのでこのレイヤにしか書けない。
   - ghq レイアウトなので root は一つで足りる。パスは `home()` で解決するため、この設定ファイルはマシンを跨いでそのまま使える。
   - シングルクォートは意図的である。Windows の `home()` はバックスラッシュを返すので、TOML の基本文字列だとそれが不正なエスケープになる。

## 制約

- 変更は `config.toml` への 1 テーブル追加のみ。既存のキーやコメントは書き換えない。
- 検証: 変更後に `magi repos` がエラーなくチェックアウト一覧を出力すること。空リストやパースエラーなら未完成。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added machine-wide configuration for recognizing source checkout locations.
  * Supports home-directory-based paths across operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->