### PR TITLE
fix: check for magi updates every ten minutes

### DIFF
--- a/home/.config/magi/config.toml
+++ b/home/.config/magi/config.toml
@@ -145,6 +145,11 @@ land_approval = false
 
 [update]
 mode = "notify"
+# 常駐する magi web はこの間隔で新しいリリースを確認する。既定の1日では、
+# v0.10.0 の公開直後にも更新に気づかず、手動で再起動することになった。
+# 60秒の下限は GitHub の未認証レート制限（毎時60回）に合わせたものなので、
+# 下限ぎりぎりにはせず10分にする。毎時6回なら他の用途の余地も残せる。
+interval = "10m"
 
 # Every checkout on this machine is jj-colocated, and jj keeps git's HEAD
 # detached at the working-copy commit - so magi can never infer the base branch


### PR DESCRIPTION
The long-running magi web deck was still using the default daily update interval, so it had not noticed v0.14.0 after publication. Set the machine-wide update interval to 10 minutes and retain notify mode, leaving installation under operator control.

Only the interval and its Japanese rationale comments change in home/.config/magi/config.toml. magi v0.14.0 review cab3 approved commit77a9b684 with both reviewers reporting zero findings and no timeouts. The gate parsed TOML and verified that all other values and text were unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release checks now run every 10 minutes for the resident web process, instead of once per day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->